### PR TITLE
Storing session IDs to avoid accessing protected routes with old cookies

### DIFF
--- a/app/middleware/auth_middleware.py
+++ b/app/middleware/auth_middleware.py
@@ -2,65 +2,63 @@ from functools import wraps
 from flask import request, jsonify, session, Blueprint
 import jwt
 from config.auth_config import AuthMethod, AuthConfig
-from services.auth_service import blacklisted_tokens
+from services.auth_service import blacklisted_tokens, invalidated_sessions
 
 class AuthMiddleware:
-    def __init__(self, auth_config: AuthConfig):
-        self.auth_config = auth_config
+    def __init__(self, config: AuthConfig):
+        self.config = config
 
-    def protect_blueprint(self, blueprint: Blueprint):
+    def protect_blueprint(self, blueprint):
+        """Add authentication middleware to all routes in a blueprint"""
         @blueprint.before_request
-        def verify_request():
-            if self.auth_config.auth_method == AuthMethod.NONE:
+        @wraps(blueprint)
+        def authenticate():
+            if self.config.auth_method == AuthMethod.NONE:
                 return None
 
-            auth_handlers = {
-                AuthMethod.API_KEY: self._handle_api_key,
-                AuthMethod.JWT: self._handle_jwt,
-                AuthMethod.SESSION: self._handle_session
-            }
+            if self.config.auth_method == AuthMethod.API_KEY:
+                return self._validate_api_key()
+            elif self.config.auth_method == AuthMethod.JWT:
+                return self._validate_jwt()
+            elif self.config.auth_method == AuthMethod.SESSION:
+                return self._validate_session()
 
-            handler = auth_handlers.get(self.auth_config.auth_method)
-            if not handler:
-                return jsonify({"error": "Invalid authentication method"}), 500
-
-            result = handler()
-            if result is not True:
-                return result
-
-            return None
-
-    def _handle_api_key(self):
+    def _validate_api_key(self):
+        """Validate API key from request header"""
         api_key = request.headers.get('X-API-Key')
         if not api_key:
             return jsonify({"error": "API key is required"}), 401
-        if api_key != self.auth_config.api_key:
+        if api_key != self.config.api_key:
             return jsonify({"error": "Invalid API key"}), 401
-        return True
+        return None
 
-    def _handle_jwt(self):
+    def _validate_jwt(self):
+        """Validate JWT from Authorization header"""
         auth_header = request.headers.get('Authorization')
         if not auth_header or not auth_header.startswith('Bearer '):
             return jsonify({"error": "JWT token is required"}), 401
-        
+
         token = auth_header.split(' ')[1]
         if token in blacklisted_tokens:
             return jsonify({"error": "You have been logged out. Please log in again."}), 401
-        
+
         try:
-            jwt.decode(
-                token, 
-                self.auth_config.jwt_secret, 
-                algorithms=["HS256"],
-                options={"verify_exp": True}
-            )
-            return True
+            jwt.decode(token, self.config.jwt_secret, algorithms=["HS256"])
+            return None
         except jwt.ExpiredSignatureError:
             return jsonify({"error": "Token has expired"}), 401
         except jwt.InvalidTokenError as e:
             return jsonify({"error": f"Invalid JWT token: {str(e)}"}), 401
 
-    def _handle_session(self):
-        if not session.get('authenticated'):
+    def _validate_session(self):
+        """Validate session authentication"""
+        if not session.get("authenticated"):
             return jsonify({"error": "Valid session required"}), 401
-        return True 
+            
+        # Check if session has been invalidated
+        current_session = request.cookies.get('session')
+        if current_session and current_session in invalidated_sessions:
+            session.clear()
+            return jsonify({"error": "Session has been invalidated"}), 401
+            
+        return None 

--- a/test/auth_api_collection.json
+++ b/test/auth_api_collection.json
@@ -933,7 +933,40 @@
 					}
 				},
 				{
-					"name": "6. Logout with Session",
+					"name": "6. Save Session Cookie Before Logout",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Save the current session cookie for later testing",
+									"const sessionCookie = pm.cookies.get('session');",
+									"if (sessionCookie) {",
+									"    pm.environment.set('old_session', sessionCookie);",
+									"    console.log('Saved session cookie:', sessionCookie);",
+									"}",
+									"",
+									"pm.test('Status code is 200', function() {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"url": {
+							"raw": "http://localhost:8000/todos",
+							"protocol": "http",
+							"host": ["localhost"],
+							"port": "8000",
+							"path": ["todos"]
+						}
+					}
+				},
+				{
+					"name": "7. Logout with Session",
 					"event": [
 						{
 							"listen": "test",
@@ -959,7 +992,7 @@
 					}
 				},
 				{
-					"name": "7. Try to Get Todos after Logout (Should Fail)",
+					"name": "8. Try to Get Todos with Normal Request after Logout (Should Fail)",
 					"event": [
 						{
 							"listen": "test",
@@ -990,7 +1023,45 @@
 					}
 				},
 				{
-					"name": "8. Get API Documentation with Session",
+					"name": "9. Try to Get Todos with Old Session Cookie (Should Fail)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 401', function() {",
+									"    pm.response.to.have.status(401);",
+									"});",
+									"",
+									"pm.test('Error message is correct', function() {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.error).to.equal('Session has been invalidated');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Cookie",
+								"value": "session={{old_session}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:8000/todos",
+							"protocol": "http",
+							"host": ["localhost"],
+							"port": "8000",
+							"path": ["todos"]
+						}
+					}
+				},
+				{
+					"name": "10. Get API Documentation with Session",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION
The way we used to logout users using session auth had a flaw that allowed clients with old session cookies to access protected routes, now we are storing a list of invalidated session IDs