### PR TITLE
Handling other 400 errors using JSON format

### DIFF
--- a/app/routes/errors.py
+++ b/app/routes/errors.py
@@ -9,6 +9,13 @@ def handle_not_found_error(error):
         "endpoint": request.path
     }), 404
 
+@errors_bp.app_errorhandler(400)
+def handle_bad_request_error(error):
+    return jsonify({
+        "error": str(error),
+        "endpoint": request.path
+    }), 400
+
 @errors_bp.app_errorhandler(500)
 def handle_internal_server_error(error):
     return jsonify({

--- a/test/auth_api_collection.json
+++ b/test/auth_api_collection.json
@@ -529,7 +529,60 @@
 					}
 				},
 				{
-					"name": "7d. Successful Logout with Both Tokens",
+					"name": "7d. Try Logout with Invalid JSON (Should Return JSON Error)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test('Status code is 400', function() {",
+									"    pm.response.to.have.status(400);",
+									"});",
+									"",
+									"pm.test('Response is JSON', function() {",
+									"    pm.response.to.be.json;",
+									"});",
+									"",
+									"pm.test('Error message is correct', function() {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.error).to.include('400 Bad Request');",
+									"    pm.expect(jsonData.error).to.include('The browser (or proxy) sent a request that this server could not understand');",
+									"    pm.expect(jsonData.endpoint).to.equal('/auth/logout');",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{jwt_token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{ invalid json here"
+						},
+						"url": {
+							"raw": "http://localhost:8000/auth/logout",
+							"protocol": "http",
+							"host": ["localhost"],
+							"port": "8000",
+							"path": ["auth", "logout"]
+						}
+					}
+				},
+				{
+					"name": "7e. Successful Logout with Both Tokens",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION
Some endpoint would return a default response from Flask in html when receiving data in the wrong format, now I am handling those errors as JSON with middleware route